### PR TITLE
feat : 전략에 대한 ai 요약을 넣고, 조회할 때 같이 보여준다

### DIFF
--- a/auth-service/src/main/java/com/pda/auth_service/controller/AuthController.java
+++ b/auth-service/src/main/java/com/pda/auth_service/controller/AuthController.java
@@ -42,11 +42,10 @@ public class AuthController {
     public ResponseEntity<ApiResponse<Object>> signUp(
             @Valid @RequestBody AuthRequest.SignUp signUpRequest
     ) {
-        ResponseCookie responseCookie = authService.signUp(signUpRequest);
+        authService.signUp(signUpRequest);
 
         return ResponseEntity
                 .ok()
-                .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
                 .body(ApiResponse.success(
                         ResponseMessage.SIGNUP_SUCCESS.getCode(),
                         ResponseMessage.SIGNUP_SUCCESS.getMessage()

--- a/auth-service/src/main/java/com/pda/auth_service/service/AuthService.java
+++ b/auth-service/src/main/java/com/pda/auth_service/service/AuthService.java
@@ -6,6 +6,6 @@ import org.springframework.http.ResponseCookie;
 public interface AuthService {
     ResponseCookie login(String id, String password);
 
-    ResponseCookie signUp(AuthRequest.SignUp signUpRequest);
+    void signUp(AuthRequest.SignUp signUpRequest);
 
 }

--- a/auth-service/src/main/java/com/pda/auth_service/service/AuthServiceImpl.java
+++ b/auth-service/src/main/java/com/pda/auth_service/service/AuthServiceImpl.java
@@ -39,7 +39,7 @@ public class AuthServiceImpl implements AuthService {
     }
 
     @Override
-    public ResponseCookie signUp(AuthRequest.SignUp signUpRequest) {
+    public void signUp(AuthRequest.SignUp signUpRequest) {
         String hashedPw = BCrypt.hashpw(signUpRequest.memberPassword(), BCrypt.gensalt());
 
         Optional<Member> optionalMember = memberRepository.findByMemberId(signUpRequest.memberId());
@@ -51,9 +51,6 @@ public class AuthServiceImpl implements AuthService {
         Member member = Member.create(signUpRequest.memberId(), hashedPw, signUpRequest.memberName(),
                 signUpRequest.memberAccountNumber(), signUpRequest.memberAppKey(), signUpRequest.memberAppSecret());
 
-        Member savedMember = memberRepository.save(member);
-        String accessToken = tokenProvider.generateTokens(savedMember.getId().toString());
-
-        return TokenCookieManager.createCookie(accessToken);
+        memberRepository.save(member);
     }
 }

--- a/auth-service/src/main/resources/application.yml
+++ b/auth-service/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
       path: /h2-console
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     show-sql: true
     properties:
       hibernate:

--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,7 @@ project(":strategy-service") {
     dependencies {
         implementation project(":common-service")
         implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
+        implementation 'com.openai:openai-java:4.1.0'
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -81,9 +81,3 @@ project(":trading-service") {
 tasks.named('test') {
     useJUnitPlatform()
 }
-
-dependencies {
-    // ✅ 루트 모듈(H2 서버 띄우는 애플리케이션)을 위한 최소 의존성
-    implementation 'org.springframework.boot:spring-boot-starter'
-    implementation 'com.h2database:h2'
-}

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,6 @@ subprojects {
     }
 
     dependencies {
-        implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
         implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
         implementation 'org.springframework.boot:spring-boot-starter-web'
         testImplementation 'org.springframework.boot:spring-boot-starter-test'
@@ -69,6 +68,7 @@ project(":auth-service") {
 project(":strategy-service") {
     dependencies {
         implementation project(":common-service")
+        implementation 'org.springframework.boot:spring-boot-starter-data-mongodb'
     }
 }
 

--- a/common-service/src/main/java/com/pda/common_service/exception/ResourceNotFound.java
+++ b/common-service/src/main/java/com/pda/common_service/exception/ResourceNotFound.java
@@ -1,0 +1,16 @@
+package com.pda.common_service.exception;
+
+import com.pda.common_service.response.ResponseMessage;
+
+public class ResourceNotFound extends RuntimeException {
+    private final ResponseMessage responseMessage;
+
+    public ResourceNotFound(ResponseMessage responseMessage) {
+        super(responseMessage.getMessage());
+        this.responseMessage = responseMessage;
+    }
+
+    public String getCode() {
+        return responseMessage.getCode();
+    }
+}

--- a/common-service/src/main/java/com/pda/common_service/handler/GlobalExceptionHandler.java
+++ b/common-service/src/main/java/com/pda/common_service/handler/GlobalExceptionHandler.java
@@ -4,6 +4,7 @@ package com.pda.common_service.handler;
 import com.pda.common_service.exception.AuthException;
 import com.pda.common_service.exception.DuplicatedException;
 import com.pda.common_service.exception.MemberException;
+import com.pda.common_service.exception.ResourceNotFound;
 import com.pda.common_service.exception.StrategyException;
 import com.pda.common_service.response.ApiResponse;
 import org.springframework.http.HttpStatus;
@@ -60,5 +61,12 @@ public class GlobalExceptionHandler {
         return ResponseEntity
                 .badRequest()
                 .body(ApiResponse.failure("FORMAT-EXCEPTION", errorMessage));
+    }
+
+    @ExceptionHandler(ResourceNotFound.class)
+    public ResponseEntity<ApiResponse<String>> handleResourceNotFoundException(ResourceNotFound ex) {
+        return ResponseEntity
+                .status(HttpStatus.NOT_FOUND)
+                .body(ApiResponse.failure(ex.getCode(), ex.getMessage()));
     }
 }

--- a/common-service/src/main/java/com/pda/common_service/response/ResponseMessage.java
+++ b/common-service/src/main/java/com/pda/common_service/response/ResponseMessage.java
@@ -46,7 +46,12 @@ public enum ResponseMessage {
     /**
      * trade
      */
-    GET_EXECUTION_SUCCESS("GET_EXECUTION_SUCCESS", "체결 내역 가져오기를 성공했습니다.");
+    GET_EXECUTION_SUCCESS("GET_EXECUTION_SUCCESS", "체결 내역 가져오기를 성공했습니다."),
+
+    /**
+     * STOCK
+     */
+    STOCK_NOT_FOUND("STOCK_NOT_FOUND", "존재하지 않는 주식입니다");
 
     private final String code;
     private final String message;

--- a/common-service/src/main/java/com/pda/common_service/stock/MemberStock.java
+++ b/common-service/src/main/java/com/pda/common_service/stock/MemberStock.java
@@ -7,6 +7,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -21,6 +22,7 @@ public class MemberStock extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "code")
     private Stock stock;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/common-service/src/main/java/com/pda/common_service/stock/Stock.java
+++ b/common-service/src/main/java/com/pda/common_service/stock/Stock.java
@@ -3,8 +3,6 @@ package com.pda.common_service.stock;
 import com.pda.common_service.BaseEntity;
 import com.pda.common_service.stock.dto.StockInfo;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
@@ -13,9 +11,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Stock extends BaseEntity {
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
     String code;
 
     String imageUri;

--- a/common-service/src/main/java/com/pda/common_service/stock/repository/MemberStockRepository.java
+++ b/common-service/src/main/java/com/pda/common_service/stock/repository/MemberStockRepository.java
@@ -1,5 +1,6 @@
-package com.pda.common_service.stock;
+package com.pda.common_service.stock.repository;
 
+import com.pda.common_service.stock.MemberStock;
 import com.pda.common_service.user.domain.Member;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/common-service/src/main/java/com/pda/common_service/stock/repository/StockRepository.java
+++ b/common-service/src/main/java/com/pda/common_service/stock/repository/StockRepository.java
@@ -1,0 +1,7 @@
+package com.pda.common_service.stock.repository;
+
+import com.pda.common_service.stock.Stock;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StockRepository extends JpaRepository<Stock, String> {
+}

--- a/strategy-service/src/main/java/com/pda/strategy_service/StrategyServiceApplication.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/StrategyServiceApplication.java
@@ -3,10 +3,21 @@ package com.pda.strategy_service;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+import org.springframework.scheduling.annotation.EnableAsync;
 
 @SpringBootApplication(scanBasePackages = {
 		"com.pda.strategy_service",
 		"com.pda.common_service"
+})
+@EnableJpaRepositories(basePackages = {
+		"com.pda.strategy_service.repository.jpa",
+		"com.pda.common_service.user.repository",
+		"com.pda.common_service.stock.repository"
+})
+@EnableMongoRepositories(basePackages = {
+		"com.pda.strategy_service.repository.mongodb"
 })
 @EnableJpaAuditing
 public class StrategyServiceApplication {

--- a/strategy-service/src/main/java/com/pda/strategy_service/config/OpenAIConfig.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/config/OpenAIConfig.java
@@ -1,0 +1,21 @@
+package com.pda.strategy_service.config;
+
+import com.openai.client.OpenAIClient;
+import com.openai.client.okhttp.OpenAIOkHttpClient;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class OpenAIConfig {
+
+    @Value("${openai.api-key}")
+    private String openaiApiKey;
+
+    @Bean
+    public OpenAIClient openAIClient() {
+        return OpenAIOkHttpClient.builder()
+                .apiKey(openaiApiKey)
+                .build();
+    }
+}

--- a/strategy-service/src/main/java/com/pda/strategy_service/config/StrategyTemplateInitializer.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/config/StrategyTemplateInitializer.java
@@ -29,3 +29,34 @@
 //        }
 //    }
 //}
+//package com.pda.strategy_service.config;
+//
+//import com.pda.common_service.exception.StrategyTemplatesException;
+//import com.pda.common_service.response.ResponseMessage;
+//import com.pda.strategy_service.service.mongodb.StrategyTemplateService;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.boot.CommandLineRunner;
+//import org.springframework.stereotype.Component;
+//
+//@Component
+//@RequiredArgsConstructor
+//public class StrategyTemplateInitializer implements CommandLineRunner {
+//
+//    private final StrategyTemplateService strategyTemplateService;
+//
+//    @Override
+//    public void run(String... args) throws Exception {
+//        try {
+//            long existingCount = strategyTemplateService.getAllStrategyTemplates().size();
+//
+//            if (existingCount == 0) {
+//                strategyTemplateService.initializeDefaultStrategyTemplates();
+//            } else {
+//                strategyTemplateService.updateStrategyTemplates();
+//            }
+//
+//        } catch (Exception e) {
+//            throw new StrategyTemplatesException(ResponseMessage.STRATEGY_TEMPLATE_INITIALIZE_FAILED);
+//        }
+//    }
+//}

--- a/strategy-service/src/main/java/com/pda/strategy_service/config/StrategyTemplateInitializer.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/config/StrategyTemplateInitializer.java
@@ -1,31 +1,31 @@
-package com.pda.strategy_service.config;
-
-import com.pda.common_service.exception.StrategyTemplatesException;
-import com.pda.common_service.response.ResponseMessage;
-import com.pda.strategy_service.service.mongodb.StrategyTemplateService;
-import lombok.RequiredArgsConstructor;
-import org.springframework.boot.CommandLineRunner;
-import org.springframework.stereotype.Component;
-
-@Component
-@RequiredArgsConstructor
-public class StrategyTemplateInitializer implements CommandLineRunner {
-    
-    private final StrategyTemplateService strategyTemplateService;
-    
-    @Override
-    public void run(String... args) throws Exception {
-        try {
-            long existingCount = strategyTemplateService.getAllStrategyTemplates().size();
-            
-            if (existingCount == 0) {
-                strategyTemplateService.initializeDefaultStrategyTemplates();
-            } else {
-                strategyTemplateService.updateStrategyTemplates();
-            }
-            
-        } catch (Exception e) {
-            throw new StrategyTemplatesException(ResponseMessage.STRATEGY_TEMPLATE_INITIALIZE_FAILED);
-        }
-    }
-}
+//package com.pda.strategy_service.config;
+//
+//import com.pda.common_service.exception.StrategyTemplatesException;
+//import com.pda.common_service.response.ResponseMessage;
+//import com.pda.strategy_service.service.mongodb.StrategyTemplateService;
+//import lombok.RequiredArgsConstructor;
+//import org.springframework.boot.CommandLineRunner;
+//import org.springframework.stereotype.Component;
+//
+//@Component
+//@RequiredArgsConstructor
+//public class StrategyTemplateInitializer implements CommandLineRunner {
+//
+//    private final StrategyTemplateService strategyTemplateService;
+//
+//    @Override
+//    public void run(String... args) throws Exception {
+//        try {
+//            long existingCount = strategyTemplateService.getAllStrategyTemplates().size();
+//
+//            if (existingCount == 0) {
+//                strategyTemplateService.initializeDefaultStrategyTemplates();
+//            } else {
+//                strategyTemplateService.updateStrategyTemplates();
+//            }
+//
+//        } catch (Exception e) {
+//            throw new StrategyTemplatesException(ResponseMessage.STRATEGY_TEMPLATE_INITIALIZE_FAILED);
+//        }
+//    }
+//}

--- a/strategy-service/src/main/java/com/pda/strategy_service/controller/StrategyController.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/controller/StrategyController.java
@@ -38,7 +38,7 @@ public class StrategyController {
 
     @GetMapping("/{strategyId}")
     public ResponseEntity<ApiResponse<ReadStrategy>> getStrategy(@PathVariable Long strategyId) {
-        ReadStrategy readStrategy = strategyService.getMonoStrategy(strategyId);
+        ReadStrategy readStrategy = strategyService.getMonoStrategy(1L, strategyId);
 
         return ResponseEntity
                 .ok()

--- a/strategy-service/src/main/java/com/pda/strategy_service/controller/StrategyTemplateController.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/controller/StrategyTemplateController.java
@@ -14,7 +14,7 @@ import java.util.List;
 import java.util.Map;
 
 @RestController
-@RequestMapping("/api/strategy-templates")
+@RequestMapping("/api/v1/strategy-templates")
 @RequiredArgsConstructor
 public class StrategyTemplateController {
 

--- a/strategy-service/src/main/java/com/pda/strategy_service/controller/StrategyTemplateController.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/controller/StrategyTemplateController.java
@@ -1,6 +1,9 @@
 package com.pda.strategy_service.controller;
 
+import com.pda.strategy_service.domain.Strategy;
+import com.pda.strategy_service.domain.dto.StrategyMetaDto;
 import com.pda.strategy_service.domain.mongodb.StrategyTemplate;
+import com.pda.strategy_service.service.StrategyService;
 import com.pda.strategy_service.service.mongodb.StrategyTemplateService;
 import com.pda.strategy_service.service.mongodb.StrategyTemplateFileLoader;
 import lombok.RequiredArgsConstructor;
@@ -14,42 +17,51 @@ import java.util.Map;
 @RequestMapping("/api/strategy-templates")
 @RequiredArgsConstructor
 public class StrategyTemplateController {
-    
+
     private final StrategyTemplateService strategyTemplateService;
     private final StrategyTemplateFileLoader fileLoader;
-    
+    private final StrategyService strategyService;
+
     @GetMapping
     public ResponseEntity<List<StrategyTemplate>> getAllStrategyTemplates() {
         List<StrategyTemplate> templates = strategyTemplateService.getAllStrategyTemplates();
         return ResponseEntity.ok(templates);
     }
-    
+
     @GetMapping("/owner/{ownerId}")
     public ResponseEntity<List<StrategyTemplate>> getStrategyTemplatesByOwner(@PathVariable String ownerId) {
         List<StrategyTemplate> templates = strategyTemplateService.getStrategyTemplatesByOwner(ownerId);
         return ResponseEntity.ok(templates);
     }
-    
+
     @GetMapping("/search")
     public ResponseEntity<List<StrategyTemplate>> searchStrategyTemplates(@RequestParam String name) {
         List<StrategyTemplate> templates = strategyTemplateService.searchStrategyTemplatesByName(name);
         return ResponseEntity.ok(templates);
     }
-    
+
     @PostMapping("/load-from-file/{strategyName}")
     public ResponseEntity<StrategyTemplate> loadStrategyTemplateFromFile(@PathVariable String strategyName) {
         Map<String, Object> templateData = fileLoader.loadStrategyTemplateByName(strategyName);
-        if (templateData != null) {
-            StrategyTemplate template = strategyTemplateService.saveStrategyTemplate(templateData);
-            return ResponseEntity.ok(template);
-        } else {
+
+        if (templateData == null) {
             return ResponseEntity.notFound().build();
         }
+
+        // 전략 meta 저장
+        Map<String, Object> meta = (Map<String, Object>) templateData.get("meta");
+        List<String> universe = (List<String>) meta.get("universe");
+        String stockId = (universe != null && !universe.isEmpty()) ? universe.get(0) : null;
+        StrategyMetaDto strategyMeta = new StrategyMetaDto(stockId, strategyName);
+        Strategy strategy = strategyService.saveStrategy(1L, strategyMeta);
+
+        StrategyTemplate template = strategyTemplateService.saveStrategyTemplate(strategy.getId(), templateData);
+        return ResponseEntity.ok(template);
     }
-    
+
     @GetMapping("/{strategyName}/{version}")
     public ResponseEntity<StrategyTemplate> getStrategyTemplate(
-            @PathVariable String strategyName, 
+            @PathVariable String strategyName,
             @PathVariable Integer version) {
         StrategyTemplate template = strategyTemplateService.getStrategyTemplateByNameAndVersion(strategyName, version);
         if (template != null) {
@@ -58,47 +70,57 @@ public class StrategyTemplateController {
             return ResponseEntity.notFound().build();
         }
     }
-    
+
     @PostMapping
     public ResponseEntity<StrategyTemplate> saveStrategyTemplate(@RequestBody Map<String, Object> strategyJson) {
-        StrategyTemplate template = strategyTemplateService.saveStrategyTemplate(strategyJson);
+        String strategyName = (String) strategyJson.get("strategy_name");
+        Map<String, Object> meta = (Map<String, Object>) strategyJson.get("meta");
+        List<String> universe = (List<String>) meta.get("universe");
+        String stockId = (universe != null && !universe.isEmpty()) ? universe.get(0) : null;
+        System.out.println(stockId);
+        StrategyMetaDto strategyMeta = new StrategyMetaDto(stockId, strategyName);
+        Strategy strategy = strategyService.saveStrategy(1L, strategyMeta);
+        StrategyTemplate template = strategyTemplateService.saveStrategyTemplate(strategy.getId(), strategyJson);
+
         return ResponseEntity.ok(template);
     }
-    
+
     @DeleteMapping("/{strategyName}/{version}")
     public ResponseEntity<Void> deleteStrategyTemplate(
-            @PathVariable String strategyName, 
+            @PathVariable String strategyName,
             @PathVariable Integer version) {
         strategyTemplateService.deleteStrategyTemplate(strategyName, version);
         return ResponseEntity.ok().build();
     }
-    
+
     @GetMapping("/available-files")
     public ResponseEntity<List<String>> getAvailableStrategyTemplateFiles() {
         List<String> files = fileLoader.getAvailableStrategyTemplates();
         return ResponseEntity.ok(files);
     }
-    
+
     @PostMapping("/initialize")
     public ResponseEntity<String> initializeStrategyTemplates() {
         try {
             strategyTemplateService.initializeDefaultStrategyTemplates();
             return ResponseEntity.ok("Strategy templates initialized successfully");
         } catch (Exception e) {
-            return ResponseEntity.internalServerError().body("Failed to initialize strategy templates: " + e.getMessage());
+            return ResponseEntity.internalServerError()
+                    .body("Failed to initialize strategy templates: " + e.getMessage());
         }
     }
-    
+
     @PostMapping("/force-reinitialize")
     public ResponseEntity<String> forceReinitializeStrategyTemplates() {
         try {
             strategyTemplateService.forceReinitializeStrategyTemplates();
             return ResponseEntity.ok("Strategy templates force reinitialized successfully");
         } catch (Exception e) {
-            return ResponseEntity.internalServerError().body("Failed to force reinitialize strategy templates: " + e.getMessage());
+            return ResponseEntity.internalServerError()
+                    .body("Failed to force reinitialize strategy templates: " + e.getMessage());
         }
     }
-    
+
     @PostMapping("/update")
     public ResponseEntity<String> updateStrategyTemplates() {
         try {

--- a/strategy-service/src/main/java/com/pda/strategy_service/controller/dto/StrategyResponse.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/controller/dto/StrategyResponse.java
@@ -3,6 +3,8 @@ package com.pda.strategy_service.controller.dto;
 import com.pda.common_service.stock.dto.StockInfo;
 import com.pda.strategy_service.domain.dto.SimpleStrategy;
 import com.pda.strategy_service.domain.dto.StrategyDto;
+import com.pda.strategy_service.domain.dto.StrategySummaryDto;
+import com.pda.strategy_service.domain.mongodb.StrategyTemplate;
 import com.pda.strategy_service.service.dto.ProfitPoint;
 import java.math.BigDecimal;
 import java.util.List;
@@ -17,7 +19,9 @@ public class StrategyResponse {
             StockInfo stockInfo,
             SimpleStrategy strategyInfo,
             ProfitDto strategyProfit,
-            ProfitSeries profitSeries
+            StrategyTemplate strategyTemplate,
+            ProfitSeries profitSeries,
+            StrategySummaryDto strategySummary
     ) {
     }
 

--- a/strategy-service/src/main/java/com/pda/strategy_service/domain/Strategy.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/domain/Strategy.java
@@ -1,10 +1,12 @@
 package com.pda.strategy_service.domain;
 
 import com.pda.common_service.BaseEntity;
-import com.pda.common_service.stock.MemberStock;
+import com.pda.common_service.stock.Stock;
 import com.pda.common_service.stock.dto.StockInfo;
+import com.pda.common_service.user.domain.Member;
 import com.pda.strategy_service.domain.dto.SimpleStrategy;
 import com.pda.strategy_service.domain.dto.StrategyDto;
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
@@ -13,15 +15,20 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToOne;
 import java.math.BigDecimal;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
+@Builder
+@AllArgsConstructor
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Strategy extends BaseEntity {
     @Id
@@ -29,9 +36,11 @@ public class Strategy extends BaseEntity {
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)
-    private MemberStock memberStock;
+    @JoinColumn(name = "code")
+    private Stock stock;
 
-    @OneToOne
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true)
+    @JoinColumn(name = "strategy_profit_summary_id")
     private StrategyProfitSummary strategyProfitSummary;
 
     @Column(length = 100)
@@ -42,6 +51,20 @@ public class Strategy extends BaseEntity {
 
     @Enumerated(value = EnumType.STRING)
     private StrategyExistedStatus strategyExistedStatus;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    private Member member;
+
+    public static Strategy create(Stock stock, Member member, String strategyName) {
+        return Strategy.builder()
+                .member(member)
+                .strategyName(strategyName)
+                .stock(stock)
+                .strategyActivatedStatus(StrategyActivatedStatus.PENDING)
+                .strategyExistedStatus(StrategyExistedStatus.EXISTED)
+                .strategyProfitSummary(StrategyProfitSummary.create())
+                .build();
+    }
 
     public StrategyDto toDto(StockInfo stockInfo, BigDecimal profitAmount) {
         return new StrategyDto(

--- a/strategy-service/src/main/java/com/pda/strategy_service/domain/StrategyProfitSummary.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/domain/StrategyProfitSummary.java
@@ -3,18 +3,20 @@ package com.pda.strategy_service.domain;
 import com.pda.common_service.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
-import jakarta.persistence.ManyToOne;
 import java.math.BigDecimal;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 @Getter
 public class StrategyProfitSummary extends BaseEntity {
     @Id
@@ -29,4 +31,11 @@ public class StrategyProfitSummary extends BaseEntity {
 
     @Column(nullable = false, precision = 19, scale = 2)
     private BigDecimal strategyProfitSummaryProfitRate;
+
+    public static StrategyProfitSummary create() {
+        return StrategyProfitSummary.builder()
+                .strategyProfitSummaryProfitRate(BigDecimal.ZERO)
+                .strategyProfitSummaryAvgBuyPrice(BigDecimal.ZERO)
+                .strategyProfitSummaryCurrentPrice(BigDecimal.ZERO).build();
+    }
 }

--- a/strategy-service/src/main/java/com/pda/strategy_service/domain/StrategySummary.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/domain/StrategySummary.java
@@ -1,0 +1,34 @@
+package com.pda.strategy_service.domain;
+
+import com.pda.common_service.BaseEntity;
+import com.pda.strategy_service.domain.dto.StrategySummaryDto;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class StrategySummary extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne
+    private Strategy strategy;
+
+    @Column(columnDefinition = "TEXT")
+    private String summaryOverview;
+
+    @Column(columnDefinition = "TEXT")
+    private String summaryCondition;
+
+    @Column(columnDefinition = "TEXT")
+    private String summaryRisk;
+
+    public StrategySummaryDto toDto() {
+        return new StrategySummaryDto(summaryOverview, summaryCondition, summaryRisk);
+    }
+}

--- a/strategy-service/src/main/java/com/pda/strategy_service/domain/dto/StrategyMetaDto.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/domain/dto/StrategyMetaDto.java
@@ -1,0 +1,7 @@
+package com.pda.strategy_service.domain.dto;
+
+public record StrategyMetaDto(
+        String stockId,
+        String strategyName
+) {
+}

--- a/strategy-service/src/main/java/com/pda/strategy_service/domain/dto/StrategySummaryDto.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/domain/dto/StrategySummaryDto.java
@@ -1,0 +1,8 @@
+package com.pda.strategy_service.domain.dto;
+
+public record StrategySummaryDto(
+        String summaryOverview,
+        String summaryCondition,
+        String summaryRisk
+) {
+}

--- a/strategy-service/src/main/java/com/pda/strategy_service/domain/mongodb/StrategyTemplate.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/domain/mongodb/StrategyTemplate.java
@@ -26,6 +26,8 @@ public class StrategyTemplate {
     private String strategyName;
     
     private Integer version;
+
+    private Long strategyId;
     
     @Field("owner_id")
     private String ownerId;

--- a/strategy-service/src/main/java/com/pda/strategy_service/repository/StrategyProfitSummaryRepository.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/repository/StrategyProfitSummaryRepository.java
@@ -1,0 +1,7 @@
+package com.pda.strategy_service.repository;
+
+import com.pda.strategy_service.domain.StrategyProfitSummary;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StrategyProfitSummaryRepository extends JpaRepository<StrategyProfitSummary, Long> {
+}

--- a/strategy-service/src/main/java/com/pda/strategy_service/repository/StrategyRepository.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/repository/StrategyRepository.java
@@ -1,10 +1,11 @@
 package com.pda.strategy_service.repository;
 
 import com.pda.common_service.stock.MemberStock;
+import com.pda.common_service.user.domain.Member;
 import com.pda.strategy_service.domain.Strategy;
 import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface StrategyRepository extends JpaRepository<Strategy, Long> {
-    List<Strategy> findAllByMemberStock(MemberStock memberStock);
+    List<Strategy> findAllByMember(Member member);
 }

--- a/strategy-service/src/main/java/com/pda/strategy_service/repository/jpa/DailyStrategyProfitRepository.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/repository/jpa/DailyStrategyProfitRepository.java
@@ -1,4 +1,4 @@
-package com.pda.strategy_service.repository;
+package com.pda.strategy_service.repository.jpa;
 
 import com.pda.strategy_service.domain.DailyStrategyProfit;
 import com.pda.strategy_service.domain.Strategy;

--- a/strategy-service/src/main/java/com/pda/strategy_service/repository/jpa/StrategyProfitSummaryRepository.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/repository/jpa/StrategyProfitSummaryRepository.java
@@ -1,4 +1,4 @@
-package com.pda.strategy_service.repository;
+package com.pda.strategy_service.repository.jpa;
 
 import com.pda.strategy_service.domain.StrategyProfitSummary;
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/strategy-service/src/main/java/com/pda/strategy_service/repository/jpa/StrategyRepository.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/repository/jpa/StrategyRepository.java
@@ -1,6 +1,5 @@
-package com.pda.strategy_service.repository;
+package com.pda.strategy_service.repository.jpa;
 
-import com.pda.common_service.stock.MemberStock;
 import com.pda.common_service.user.domain.Member;
 import com.pda.strategy_service.domain.Strategy;
 import java.util.List;

--- a/strategy-service/src/main/java/com/pda/strategy_service/repository/jpa/StrategySummaryRepository.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/repository/jpa/StrategySummaryRepository.java
@@ -1,0 +1,9 @@
+package com.pda.strategy_service.repository.jpa;
+
+import com.pda.strategy_service.domain.Strategy;
+import com.pda.strategy_service.domain.StrategySummary;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface StrategySummaryRepository extends JpaRepository<StrategySummary, Long> {
+    StrategySummary findByStrategy(Strategy strategy);
+}

--- a/strategy-service/src/main/java/com/pda/strategy_service/repository/mongodb/StrategyTemplateRepository.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/repository/mongodb/StrategyTemplateRepository.java
@@ -19,4 +19,6 @@ public interface StrategyTemplateRepository extends MongoRepository<StrategyTemp
     List<StrategyTemplate> findByStrategyNameContainingIgnoreCase(String strategyName);
     
     void deleteByStrategyNameAndVersion(String strategyName, Integer version);
+
+    StrategyTemplate findByStrategyId(Long strategyId);
 }

--- a/strategy-service/src/main/java/com/pda/strategy_service/service/ProfitCalculator.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/service/ProfitCalculator.java
@@ -3,7 +3,7 @@ package com.pda.strategy_service.service;
 import com.pda.strategy_service.controller.dto.StrategyResponse.ProfitSeries;
 import com.pda.strategy_service.domain.DailyStrategyProfit;
 import com.pda.strategy_service.domain.Strategy;
-import com.pda.strategy_service.repository.DailyStrategyProfitRepository;
+import com.pda.strategy_service.repository.jpa.DailyStrategyProfitRepository;
 import com.pda.strategy_service.service.dto.ProfitPoint;
 import java.math.BigDecimal;
 import java.math.RoundingMode;

--- a/strategy-service/src/main/java/com/pda/strategy_service/service/StrategyService.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/service/StrategyService.java
@@ -7,6 +7,6 @@ import com.pda.strategy_service.domain.dto.StrategyMetaDto;
 
 public interface StrategyService {
     ReadStrategies getStrategies(Long memberId);
-    ReadStrategy getMonoStrategy(Long strategyId);
+    ReadStrategy getMonoStrategy(Long memberId, Long strategyId);
     Strategy saveStrategy(Long memberId, StrategyMetaDto strategyMeta);
 }

--- a/strategy-service/src/main/java/com/pda/strategy_service/service/StrategyService.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/service/StrategyService.java
@@ -2,8 +2,11 @@ package com.pda.strategy_service.service;
 
 import com.pda.strategy_service.controller.dto.StrategyResponse.ReadStrategies;
 import com.pda.strategy_service.controller.dto.StrategyResponse.ReadStrategy;
+import com.pda.strategy_service.domain.Strategy;
+import com.pda.strategy_service.domain.dto.StrategyMetaDto;
 
 public interface StrategyService {
     ReadStrategies getStrategies(Long memberId);
     ReadStrategy getMonoStrategy(Long strategyId);
+    Strategy saveStrategy(Long memberId, StrategyMetaDto strategyMeta);
 }

--- a/strategy-service/src/main/java/com/pda/strategy_service/service/StrategyServiceImpl.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/service/StrategyServiceImpl.java
@@ -1,12 +1,12 @@
 package com.pda.strategy_service.service;
 
 import com.pda.common_service.exception.MemberException;
+import com.pda.common_service.exception.ResourceNotFound;
 import com.pda.common_service.exception.StrategyException;
 import com.pda.common_service.response.ResponseMessage;
-import com.pda.common_service.stock.MemberStock;
-import com.pda.common_service.stock.MemberStockRepository;
 import com.pda.common_service.stock.Stock;
 import com.pda.common_service.stock.dto.StockInfo;
+import com.pda.common_service.stock.repository.StockRepository;
 import com.pda.common_service.user.domain.Member;
 import com.pda.common_service.user.repository.MemberRepository;
 import com.pda.strategy_service.controller.dto.StrategyResponse.ProfitDto;
@@ -16,7 +16,9 @@ import com.pda.strategy_service.controller.dto.StrategyResponse.ReadStrategy;
 import com.pda.strategy_service.domain.Strategy;
 import com.pda.strategy_service.domain.dto.SimpleStrategy;
 import com.pda.strategy_service.domain.dto.StrategyDto;
+import com.pda.strategy_service.domain.dto.StrategyMetaDto;
 import com.pda.strategy_service.repository.StrategyRepository;
+import jakarta.transaction.Transactional;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
@@ -26,31 +28,29 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class StrategyServiceImpl implements StrategyService {
-    private final MemberStockRepository memberStockRepository;
     private final MemberRepository memberRepository;
     private final StrategyRepository strategyRepository;
+    private final StockRepository stockRepository;
     private final ProfitCalculator profitCalculator;
 
     @Override
     public ReadStrategies getStrategies(Long memberId) {
         Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new MemberException(ResponseMessage.MEMBER_NOT_FOUND));
-        List<MemberStock> memberStocks = memberStockRepository.findByMember(member);
+        List<Strategy> strategies = strategyRepository.findAllByMember(member);
+
         List<StrategyDto> strategyDtos = new ArrayList<>();
 
-        for (MemberStock memberStock : memberStocks) {
-            Stock stock = memberStock.getStock();
+        for (Strategy strategy : strategies) {
+            Stock stock = strategy.getStock();
             StockInfo stockInfo = stock.toDto();
-            List<Strategy> strategies = strategyRepository.findAllByMemberStock(memberStock);
 
-            for (Strategy strategy : strategies) {
-                BigDecimal profitAmount = strategy.getStrategyProfitSummary()
-                        .getStrategyProfitSummaryCurrentPrice()
-                        .subtract(strategy.getStrategyProfitSummary().getStrategyProfitSummaryAvgBuyPrice());
+            BigDecimal profitAmount = strategy.getStrategyProfitSummary()
+                    .getStrategyProfitSummaryCurrentPrice()
+                    .subtract(strategy.getStrategyProfitSummary().getStrategyProfitSummaryAvgBuyPrice());
 
-                StrategyDto strategyDto = strategy.toDto(stockInfo, profitAmount);
-                strategyDtos.add(strategyDto);
-            }
+            StrategyDto strategyDto = strategy.toDto(stockInfo, profitAmount);
+            strategyDtos.add(strategyDto);
         }
         return new ReadStrategies(strategyDtos);
     }
@@ -64,12 +64,25 @@ public class StrategyServiceImpl implements StrategyService {
         ProfitDto strategyProfit = new ProfitDto(allCumulativeProfit, weekCumulativeProfit);
         ProfitSeries periodSeries = profitCalculator.getAllPeriodSeries(strategy);
 
-        MemberStock memberStock = strategy.getMemberStock();
-        Stock stock = memberStock.getStock();
+        Stock stock = strategy.getStock();
 
         StockInfo stockInfo = stock.toDto();
         SimpleStrategy simpleStrategy = strategy.toSimpleStrategyDto();
 
         return new ReadStrategy(stockInfo, simpleStrategy, strategyProfit, periodSeries);
+    }
+
+    @Override
+    @Transactional
+    public Strategy saveStrategy(Long memberId, StrategyMetaDto strategyMeta) {
+        Member member = memberRepository.findById(1L)
+                .orElseThrow(() -> new MemberException(ResponseMessage.MEMBER_NOT_FOUND));
+
+        Stock stock = stockRepository.findById(strategyMeta.stockId())
+                .orElseThrow(() -> new ResourceNotFound(ResponseMessage.STOCK_NOT_FOUND));
+
+        Strategy strategy = Strategy.create(stock, member, strategyMeta.strategyName());
+
+        return strategyRepository.save(strategy);
     }
 }

--- a/strategy-service/src/main/java/com/pda/strategy_service/service/StrategyServiceImpl.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/service/StrategyServiceImpl.java
@@ -1,5 +1,6 @@
 package com.pda.strategy_service.service;
 
+import com.pda.common_service.exception.AuthException;
 import com.pda.common_service.exception.MemberException;
 import com.pda.common_service.exception.ResourceNotFound;
 import com.pda.common_service.exception.StrategyException;
@@ -14,14 +15,20 @@ import com.pda.strategy_service.controller.dto.StrategyResponse.ProfitSeries;
 import com.pda.strategy_service.controller.dto.StrategyResponse.ReadStrategies;
 import com.pda.strategy_service.controller.dto.StrategyResponse.ReadStrategy;
 import com.pda.strategy_service.domain.Strategy;
+import com.pda.strategy_service.domain.StrategySummary;
 import com.pda.strategy_service.domain.dto.SimpleStrategy;
 import com.pda.strategy_service.domain.dto.StrategyDto;
 import com.pda.strategy_service.domain.dto.StrategyMetaDto;
-import com.pda.strategy_service.repository.StrategyRepository;
+import com.pda.strategy_service.domain.dto.StrategySummaryDto;
+import com.pda.strategy_service.domain.mongodb.StrategyTemplate;
+import com.pda.strategy_service.repository.jpa.StrategyRepository;
+import com.pda.strategy_service.repository.jpa.StrategySummaryRepository;
+import com.pda.strategy_service.repository.mongodb.StrategyTemplateRepository;
 import jakarta.transaction.Transactional;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -32,6 +39,8 @@ public class StrategyServiceImpl implements StrategyService {
     private final StrategyRepository strategyRepository;
     private final StockRepository stockRepository;
     private final ProfitCalculator profitCalculator;
+    private final StrategySummaryRepository strategySummaryRepository;
+    private final StrategyTemplateRepository strategyTemplateRepository;
 
     @Override
     public ReadStrategies getStrategies(Long memberId) {
@@ -56,20 +65,31 @@ public class StrategyServiceImpl implements StrategyService {
     }
 
     @Override
-    public ReadStrategy getMonoStrategy(Long strategyId) {
+    public ReadStrategy getMonoStrategy(Long memberId, Long strategyId) {
         Strategy strategy = strategyRepository.findById(strategyId)
                 .orElseThrow(() -> new StrategyException(ResponseMessage.STRATEGY_NOT_FOUND));
+
+        if (!(Objects.equals(strategy.getMember().getId(), memberId))) {
+            throw new AuthException(ResponseMessage.PERMISSION_DENY);
+        }
+
+        StrategySummary strategySummary = strategySummaryRepository.findByStrategy(strategy);
+        StrategySummaryDto strategySummaryDto = strategySummary.toDto();
+
         BigDecimal allCumulativeProfit = profitCalculator.allCumulativeProfit(strategy);
         BigDecimal weekCumulativeProfit = profitCalculator.weekCumulativeProfit(strategy);
         ProfitDto strategyProfit = new ProfitDto(allCumulativeProfit, weekCumulativeProfit);
         ProfitSeries periodSeries = profitCalculator.getAllPeriodSeries(strategy);
+
+        StrategyTemplate strategyTemplate = strategyTemplateRepository.findByStrategyId(strategyId);
 
         Stock stock = strategy.getStock();
 
         StockInfo stockInfo = stock.toDto();
         SimpleStrategy simpleStrategy = strategy.toSimpleStrategyDto();
 
-        return new ReadStrategy(stockInfo, simpleStrategy, strategyProfit, periodSeries);
+        return new ReadStrategy(stockInfo, simpleStrategy, strategyProfit, strategyTemplate, periodSeries,
+                strategySummaryDto);
     }
 
     @Override

--- a/strategy-service/src/main/java/com/pda/strategy_service/service/StrategySummaryService.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/service/StrategySummaryService.java
@@ -1,0 +1,139 @@
+package com.pda.strategy_service.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.openai.client.OpenAIClient;
+import com.openai.models.ChatModel;
+import com.openai.models.chat.completions.ChatCompletion;
+import com.openai.models.chat.completions.ChatCompletionCreateParams;
+import com.pda.common_service.exception.ResourceNotFound;
+import com.pda.common_service.response.ResponseMessage;
+import com.pda.strategy_service.domain.Strategy;
+import com.pda.strategy_service.domain.StrategySummary;
+import com.pda.strategy_service.repository.jpa.StrategyRepository;
+import com.pda.strategy_service.repository.jpa.StrategySummaryRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class StrategySummaryService {
+
+    private final OpenAIClient openAIClient;
+    private final StrategyRepository strategyRepository;
+    private final StrategySummaryRepository strategySummaryRepository;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    public String generateSummary(String strategyJson) {
+        try {
+            String prompt = """
+                    📌 [목표]
+                    너는 전문 트레이딩 전략 분석가이자 AI 리포트 작성자야.
+                    아래 JSON은 사용자가 직접 구성한 자동매매 전략 설정이야.
+                    이 데이터를 바탕으로, 전략의 목적, 조건, 리스크를 세 부분으로 나눠 **구조화된 요약(JSON)** 을 생성해줘.
+                    
+                    ⚙️ [출력 형식 - JSON]
+                    {
+                      "summaryOverview": "string",
+                      "summaryCondition": "string",
+                      "summaryRisk": "string"
+                    }
+                    
+                    🧭 [세부 작성 규칙]
+                    1️⃣ summaryOverview — "전략 개요"
+                    - 전략의 핵심 의도와 작동 방식을 한 문단으로 요약
+                    
+                    2️⃣ summaryCondition — "매매 조건 요약"
+                    - 매수(`buy`) 또는 매도(`sell`) 조건이 존재하는 경우에만 포함
+                    - **“매수:” 또는 “매도:” 같은 단어를 쓰지 말 것**
+                    - 매수만 있으면 그 조건만 자연스럽게 문장으로 작성
+                    - 매도만 있으면 그 조건만 자연스럽게 문장으로 작성
+                    - 두 조건이 모두 있을 경우 자연스럽게 하나의 문단으로 연결 (예: “매수 시에는 …하며, 매도 시에는 …한다.”)
+                    - 각 조건은 핵심적인 트리거와 기준만 요약
+                    
+                    3️⃣ summaryRisk — "리스크 요약"
+                    - 전략의 약점, 오탐 가능성, 변동성에 대한 주의사항을 간결히 요약
+                    
+                    🎯 [작성 시 유의]
+                    - 반드시 JSON 형태로 출력할 것
+                    - 불필요한 설명, 문장, 구분 단어(‘매도 조건 없음’ 등)는 절대 금지
+                    - 자연스러운 한국어로 핵심만 작성
+                    - 전략 데이터에 없는 항목은 언급하지 말 것
+                    
+                    📘 [입력 전략 데이터]:
+                    """ + strategyJson;
+
+            ChatCompletionCreateParams params = ChatCompletionCreateParams.builder()
+                    .model(ChatModel.GPT_4O_MINI)
+                    .addUserMessage(prompt)
+                    .temperature(0.4)
+                    .maxCompletionTokens(500)
+                    .build();
+
+            ChatCompletion completion = openAIClient.chat()
+                    .completions()
+                    .create(params);
+
+            String result = completion.choices().get(0).message().content().orElse("").trim();
+            return result;
+
+        } catch (Exception e) {
+            return """
+                    {
+                      "summaryOverview": "요약 생성 중 오류가 발생했습니다.",
+                      "summaryCondition": "",
+                      "summaryRisk": ""
+                    }
+                    """;
+        }
+    }
+
+    @Transactional
+    public StrategySummary generateSummaryAndSave(Long strategyId, String strategyJson) {
+        Strategy strategy = strategyRepository.findById(strategyId)
+                .orElseThrow(() -> new ResourceNotFound(ResponseMessage.STRATEGY_NOT_FOUND));
+        System.out.println(strategy);
+        try {
+            String aiResponse = generateSummary(strategyJson);
+            System.out.println(aiResponse);
+            String cleaned = aiResponse
+                    .replaceAll("(?s)```json", "")
+                    .replaceAll("(?s)```", "")
+                    .trim();
+
+            JsonNode jsonNode = objectMapper.readTree(cleaned);
+            String overview = jsonNode.path("summaryOverview").asText("");
+            String risk = jsonNode.path("summaryRisk").asText("");
+
+            String conditionText;
+            JsonNode conditionNode = jsonNode.path("summaryCondition");
+            if (conditionNode.isObject()) {
+                conditionText = objectMapper.writeValueAsString(conditionNode);
+            } else {
+                conditionText = conditionNode.asText("");
+            }
+
+            StrategySummary summary = StrategySummary.builder()
+                    .strategy(strategy)
+                    .summaryOverview(overview)
+                    .summaryCondition(conditionText)
+                    .summaryRisk(risk)
+                    .build();
+
+            saveSummary(summary);
+            return summary;
+
+        } catch (Exception e) {
+            throw new RuntimeException("요약 저장 실패", e);
+        }
+    }
+
+    @Transactional
+    public void saveSummary(StrategySummary summary) {
+        strategySummaryRepository.save(summary);
+    }
+}

--- a/strategy-service/src/main/java/com/pda/strategy_service/service/mongodb/StrategyTemplateFileLoader.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/service/mongodb/StrategyTemplateFileLoader.java
@@ -18,17 +18,17 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 public class StrategyTemplateFileLoader {
-    
+
     private final ResourceLoader resourceLoader;
     private final ObjectMapper objectMapper;
-    
+
     public List<Map<String, Object>> loadAllStrategyTemplates() {
         List<Map<String, Object>> templates = new ArrayList<>();
-        
+
         try {
             Resource[] resources = ResourcePatternUtils.getResourcePatternResolver(resourceLoader)
                     .getResources("classpath:strategy-templates/*.json");
-            
+
             for (Resource resource : resources) {
                 try {
                     Map<String, Object> template = loadStrategyTemplateFromFile(resource);
@@ -39,64 +39,64 @@ public class StrategyTemplateFileLoader {
                     throw new StrategyTemplatesException(ResponseMessage.STRATEGY_TEMPLATE_FILE_READ_FAILED);
                 }
             }
-            
+
         } catch (IOException e) {
             throw new StrategyTemplatesException(ResponseMessage.STRATEGY_TEMPLATE_FILE_READ_FAILED);
         }
-        
+
         return templates;
     }
-    
+
     public Map<String, Object> loadStrategyTemplateFromFile(Resource resource) {
         try (InputStream inputStream = resource.getInputStream()) {
             @SuppressWarnings("unchecked")
             Map<String, Object> template = objectMapper.readValue(inputStream, Map.class);
-            
+
             String filename = resource.getFilename();
             if (filename != null && filename.endsWith(".json") && !template.containsKey("strategy_name")) {
                 String strategyName = filename.substring(0, filename.lastIndexOf(".json"));
                 template.put("strategy_name", strategyName);
             }
-            
+
             return template;
         } catch (IOException e) {
             return null;
         }
     }
-    
+
     public Map<String, Object> loadStrategyTemplateByName(String strategyName) {
         try {
             String filePath = "classpath:strategy-templates/" + strategyName + ".json";
             Resource resource = resourceLoader.getResource(filePath);
-            
+
             if (!resource.exists()) {
                 return null;
             }
-            
+
             return loadStrategyTemplateFromFile(resource);
         } catch (Exception e) {
             return null;
         }
     }
-    
+
     public List<String> getAvailableStrategyTemplates() {
         List<String> templates = new ArrayList<>();
-        
+
         try {
             Resource[] resources = ResourcePatternUtils.getResourcePatternResolver(resourceLoader)
                     .getResources("classpath:strategy-templates/*.json");
-            
+
             for (Resource resource : resources) {
                 String filename = resource.getFilename();
                 if (filename != null && filename.endsWith(".json")) {
                     templates.add(filename.substring(0, filename.lastIndexOf(".json")));
                 }
             }
-            
+
         } catch (IOException e) {
             throw new StrategyTemplatesException(ResponseMessage.STRATEGY_TEMPLATE_FILE_READ_FAILED);
         }
-        
+
         return templates;
     }
 }

--- a/strategy-service/src/main/java/com/pda/strategy_service/service/mongodb/StrategyTemplateService.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/service/mongodb/StrategyTemplateService.java
@@ -7,8 +7,9 @@ import java.util.Map;
 
 public interface StrategyTemplateService {
     
+    StrategyTemplate saveStrategyTemplate(Long strategyMetaId, Map<String, Object> strategyJson);
     StrategyTemplate saveStrategyTemplate(Map<String, Object> strategyJson);
-    
+
     List<StrategyTemplate> getAllStrategyTemplates();
     
     List<StrategyTemplate> getStrategyTemplatesByOwner(String ownerId);
@@ -18,10 +19,10 @@ public interface StrategyTemplateService {
     List<StrategyTemplate> searchStrategyTemplatesByName(String strategyName);
     
     void deleteStrategyTemplate(String strategyName, Integer version);
-    
+
     void initializeDefaultStrategyTemplates();
-    
+
     void forceReinitializeStrategyTemplates();
-    
+
     void updateStrategyTemplates();
 }

--- a/strategy-service/src/main/java/com/pda/strategy_service/service/mongodb/StrategyTemplateService.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/service/mongodb/StrategyTemplateService.java
@@ -8,6 +8,7 @@ import java.util.Map;
 public interface StrategyTemplateService {
     
     StrategyTemplate saveStrategyTemplate(Long strategyMetaId, Map<String, Object> strategyJson);
+
     StrategyTemplate saveStrategyTemplate(Map<String, Object> strategyJson);
 
     List<StrategyTemplate> getAllStrategyTemplates();

--- a/strategy-service/src/main/java/com/pda/strategy_service/service/mongodb/StrategyTemplateServiceImpl.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/service/mongodb/StrategyTemplateServiceImpl.java
@@ -3,29 +3,28 @@ package com.pda.strategy_service.service.mongodb;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pda.common_service.exception.StrategyTemplatesException;
 import com.pda.common_service.response.ResponseMessage;
-import com.pda.strategy_service.domain.Strategy;
-import com.pda.strategy_service.domain.dto.StrategyMetaDto;
 import com.pda.strategy_service.domain.mongodb.StrategyTemplate;
-import com.pda.strategy_service.repository.StrategyProfitSummaryRepository;
 import com.pda.strategy_service.repository.mongodb.StrategyTemplateRepository;
-import com.pda.strategy_service.service.StrategyService;
+import com.pda.strategy_service.service.StrategySummaryService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
 public class StrategyTemplateServiceImpl implements StrategyTemplateService {
     private final StrategyTemplateRepository strategyTemplateRepository;
     private final StrategyTemplateFileLoader fileLoader;
+    private final StrategySummaryService strategySummaryService;
 
 
     @Override
+    @Transactional
     public StrategyTemplate saveStrategyTemplate(Long strategyMetaId, Map<String, Object> strategyJson) {
         try {
             StrategyTemplate strategyTemplate = StrategyTemplate.builder()
@@ -39,8 +38,15 @@ public class StrategyTemplateServiceImpl implements StrategyTemplateService {
                     .createdAt(LocalDateTime.now())
                     .updatedAt(LocalDateTime.now())
                     .build();
-            
-            return strategyTemplateRepository.save(strategyTemplate);
+
+            StrategyTemplate savedStrategyTemplate = strategyTemplateRepository.save(strategyTemplate);
+
+            String jsonString = new ObjectMapper().writeValueAsString(strategyJson);
+
+            strategySummaryService.generateSummaryAndSave(strategyMetaId, jsonString);
+
+            return savedStrategyTemplate;
+
         } catch (Exception e) {
             throw new StrategyTemplatesException(ResponseMessage.STRATEGY_TEMPLATE_SAVE_FAILED);
         }
@@ -96,7 +102,6 @@ public class StrategyTemplateServiceImpl implements StrategyTemplateService {
     public void initializeDefaultStrategyTemplates() {
         try {
             List<Map<String, Object>> templates = fileLoader.loadAllStrategyTemplates();
-
             if (templates.isEmpty()) {
                 return;
             }

--- a/strategy-service/src/main/java/com/pda/strategy_service/service/mongodb/StrategyTemplateServiceImpl.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/service/mongodb/StrategyTemplateServiceImpl.java
@@ -3,8 +3,12 @@ package com.pda.strategy_service.service.mongodb;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.pda.common_service.exception.StrategyTemplatesException;
 import com.pda.common_service.response.ResponseMessage;
+import com.pda.strategy_service.domain.Strategy;
+import com.pda.strategy_service.domain.dto.StrategyMetaDto;
 import com.pda.strategy_service.domain.mongodb.StrategyTemplate;
+import com.pda.strategy_service.repository.StrategyProfitSummaryRepository;
 import com.pda.strategy_service.repository.mongodb.StrategyTemplateRepository;
+import com.pda.strategy_service.service.StrategyService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -17,11 +21,31 @@ import java.util.Optional;
 @Service
 @RequiredArgsConstructor
 public class StrategyTemplateServiceImpl implements StrategyTemplateService {
-    
     private final StrategyTemplateRepository strategyTemplateRepository;
     private final StrategyTemplateFileLoader fileLoader;
-    private final ObjectMapper objectMapper;
-    
+
+
+    @Override
+    public StrategyTemplate saveStrategyTemplate(Long strategyMetaId, Map<String, Object> strategyJson) {
+        try {
+            StrategyTemplate strategyTemplate = StrategyTemplate.builder()
+                    .strategyId(strategyMetaId)
+                    .strategyName((String) strategyJson.get("strategy_name"))
+                    .version((Integer) strategyJson.get("version"))
+                    .ownerId((String) strategyJson.get("owner_id"))
+                    .meta((Map<String, Object>) strategyJson.get("meta"))
+                    .buy((Map<String, Object>) strategyJson.get("buy"))
+                    .sell((Map<String, Object>) strategyJson.get("sell"))
+                    .createdAt(LocalDateTime.now())
+                    .updatedAt(LocalDateTime.now())
+                    .build();
+            
+            return strategyTemplateRepository.save(strategyTemplate);
+        } catch (Exception e) {
+            throw new StrategyTemplatesException(ResponseMessage.STRATEGY_TEMPLATE_SAVE_FAILED);
+        }
+    }
+
     @Override
     public StrategyTemplate saveStrategyTemplate(Map<String, Object> strategyJson) {
         try {
@@ -35,7 +59,7 @@ public class StrategyTemplateServiceImpl implements StrategyTemplateService {
                     .createdAt(LocalDateTime.now())
                     .updatedAt(LocalDateTime.now())
                     .build();
-            
+
             return strategyTemplateRepository.save(strategyTemplate);
         } catch (Exception e) {
             throw new StrategyTemplatesException(ResponseMessage.STRATEGY_TEMPLATE_SAVE_FAILED);
@@ -67,16 +91,16 @@ public class StrategyTemplateServiceImpl implements StrategyTemplateService {
     public void deleteStrategyTemplate(String strategyName, Integer version) {
         strategyTemplateRepository.deleteByStrategyNameAndVersion(strategyName, version);
     }
-    
+
     @Override
     public void initializeDefaultStrategyTemplates() {
         try {
             List<Map<String, Object>> templates = fileLoader.loadAllStrategyTemplates();
-            
+
             if (templates.isEmpty()) {
                 return;
             }
-            
+
             for (Map<String, Object> template : templates) {
                 try {
                     saveStrategyTemplate(template);
@@ -84,23 +108,23 @@ public class StrategyTemplateServiceImpl implements StrategyTemplateService {
                     throw new StrategyTemplatesException(ResponseMessage.STRATEGY_TEMPLATE_INITIALIZE_FAILED);
                 }
             }
-            
+
         } catch (Exception e) {
             throw new StrategyTemplatesException(ResponseMessage.STRATEGY_TEMPLATE_INITIALIZE_FAILED);
         }
     }
-    
+
     @Override
     public void forceReinitializeStrategyTemplates() {
         try {
             strategyTemplateRepository.deleteAll();
-            
+
             List<Map<String, Object>> templates = fileLoader.loadAllStrategyTemplates();
-            
+
             if (templates.isEmpty()) {
                 return;
             }
-            
+
             for (Map<String, Object> template : templates) {
                 try {
                     saveStrategyTemplate(template);
@@ -108,32 +132,32 @@ public class StrategyTemplateServiceImpl implements StrategyTemplateService {
                     throw new StrategyTemplatesException(ResponseMessage.STRATEGY_TEMPLATE_FORCE_REINITIALIZE_FAILED);
                 }
             }
-            
+
         } catch (Exception e) {
             throw new StrategyTemplatesException(ResponseMessage.STRATEGY_TEMPLATE_FORCE_REINITIALIZE_FAILED);
         }
     }
-    
+
     @Override
     public void updateStrategyTemplates() {
         try {
             List<Map<String, Object>> fileTemplates = fileLoader.loadAllStrategyTemplates();
-            
+
             if (fileTemplates.isEmpty()) {
                 return;
             }
-            
+
             int updatedCount = 0;
             int createdCount = 0;
-            
+
             for (Map<String, Object> fileTemplate : fileTemplates) {
                 try {
                     String strategyName = (String) fileTemplate.get("strategy_name");
                     Integer version = (Integer) fileTemplate.get("version");
-                    
-                    Optional<StrategyTemplate> existingTemplate = 
+
+                    Optional<StrategyTemplate> existingTemplate =
                         strategyTemplateRepository.findByStrategyNameAndVersion(strategyName, version);
-                    
+
                     if (existingTemplate.isPresent()) {
                         StrategyTemplate updatedTemplate = StrategyTemplate.builder()
                                 .id(existingTemplate.get().getId())
@@ -146,20 +170,20 @@ public class StrategyTemplateServiceImpl implements StrategyTemplateService {
                                 .createdAt(existingTemplate.get().getCreatedAt())
                                 .updatedAt(LocalDateTime.now())
                                 .build();
-                        
+
                         strategyTemplateRepository.save(updatedTemplate);
                         updatedCount++;
-                        
+
                     } else {
                         saveStrategyTemplate(fileTemplate);
                         createdCount++;
                     }
-                    
+
                 } catch (Exception e) {
                     throw new StrategyTemplatesException(ResponseMessage.STRATEGY_TEMPLATE_UPDATE_FAILED);
                 }
             }
-            
+
         } catch (Exception e) {
             throw new StrategyTemplatesException(ResponseMessage.STRATEGY_TEMPLATE_UPDATE_FAILED);
         }

--- a/strategy-service/src/main/resources/application.yml
+++ b/strategy-service/src/main/resources/application.yml
@@ -19,7 +19,7 @@ spring:
 
   data:
     mongodb:
-      uri: mongodb+srv://pda_user:<password는 우리 프로젝트 공유 파일 참고>@modular1.l9vuztw.mongodb.net/?retryWrites=true&w=majority&appName=modular1
+      uri: mongodb+srv://pda_user:<비번은프로젝트 보세용>@modular1.l9vuztw.mongodb.net/?retryWrites=true&w=majority&appName=modular1
       database: pda-db
   sql:
     init:
@@ -27,3 +27,8 @@ spring:
 
 server:
   port: 8080
+
+openai:
+  api-key: ${OPENAI_API_KEY}
+  model: gpt-4o-mini
+  temperature: 0.4

--- a/strategy-service/src/main/resources/application.yml
+++ b/strategy-service/src/main/resources/application.yml
@@ -10,7 +10,7 @@ spring:
       path: /h2-console
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: none
     show-sql: true
     properties:
       hibernate:
@@ -19,11 +19,11 @@ spring:
 
   data:
     mongodb:
-      uri:
-      
+      uri: mongodb+srv://pda_user:<password는 우리 프로젝트 공유 파일 참고>@modular1.l9vuztw.mongodb.net/?retryWrites=true&w=majority&appName=modular1
+      database: pda-db
   sql:
     init:
       mode: always
-      
+
 server:
   port: 8080

--- a/trading-service/src/main/java/com/pda/trading_service/service/TradeExecutionServiceImpl.java
+++ b/trading-service/src/main/java/com/pda/trading_service/service/TradeExecutionServiceImpl.java
@@ -1,6 +1,5 @@
 package com.pda.trading_service.service;
 
-import com.pda.common_service.stock.MemberStockRepository;
 import com.pda.trading_service.controller.dto.TradeExecutionResponseDto;
 import com.pda.trading_service.controller.dto.TradeExecutionResponseDto.ReadTradeExecution;
 import com.pda.trading_service.domain.execution.TradeExecution;


### PR DESCRIPTION
## 📌 feat : 전략 상세의 수익률과 주식 정보 전략 정보를 구현한다

---

## 🛠 작업 내용

- [x]  새로운 기능 추가
- [x]  버그 수정
- [x]  리팩토링
- [ ]  문서 수정

### 상세 내용

- 전략 생성 할 때 ai 요약 추가
- 회원가입 쿠키 반환 제거
- 전략 보여줄 때 ai 요약 반환

---

## 🔍 테스트 방법

- [x]  로컬에서 직접 실행
- [ ]  단위 테스트 통과
- [ ]  통합 테스트 검증 완료
- [ ] 추후 진행 예정

---

## 📸 스크린샷 (선택)
---

## 📎 관련 이슈
Closes #6