### PR TITLE
feat: 전략 Pod 리소스 최적화

### DIFF
--- a/strategy-service/src/main/java/com/pda/strategy_service/service/KubernetesPodManager.java
+++ b/strategy-service/src/main/java/com/pda/strategy_service/service/KubernetesPodManager.java
@@ -220,14 +220,14 @@ public class KubernetesPodManager {
     volumeMount.setSubPath("strategy.py");
     container.setVolumeMounts(List.of(volumeMount));
 
-    // 리소스 제한 설정
+    // 리소스 제한 설정 (최적화: 실제 사용량 기반)
     V1ResourceRequirements resources = new V1ResourceRequirements();
     resources.setRequests(Map.of(
         "memory", io.kubernetes.client.custom.Quantity.fromString("128Mi"),
-        "cpu", io.kubernetes.client.custom.Quantity.fromString("100m")));
+        "cpu", io.kubernetes.client.custom.Quantity.fromString("50m")));
     resources.setLimits(Map.of(
-        "memory", io.kubernetes.client.custom.Quantity.fromString("512Mi"),
-        "cpu", io.kubernetes.client.custom.Quantity.fromString("500m")));
+        "memory", io.kubernetes.client.custom.Quantity.fromString("256Mi"),
+        "cpu", io.kubernetes.client.custom.Quantity.fromString("100m")));
     container.setResources(resources);
 
     spec.setContainers(List.of(container));


### PR DESCRIPTION
실제 사용량 기반으로 리소스 요청/제한 최적화:
- CPU Request: 100m → 50m (50% 절감)
- CPU Limit: 500m → 100m (80% 절감)
- 메모리 Request: 256Mi → 128Mi (50% 절감)
- 메모리 Limit: 512Mi → 256Mi (50% 절감)

현재 실제 사용량: CPU 3m, 메모리 22Mi
안전 여유: CPU 16배, 메모리 6배 확보